### PR TITLE
Linux fixes

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -271,7 +271,7 @@ class CommandProcessor:
             
     def load_shortcuts(self):
         config = App.get_running_app().config
-        for shortcut in config.items('command_shortcuts'):
+        for shortcut in config.items('command-shortcuts'):
             self.shortcuts[shortcut[0]] = shortcut[1]
 
     def get_commands(self):

--- a/src/inventory.py
+++ b/src/inventory.py
@@ -24,7 +24,7 @@ class UserInventory(Popup):
         self.user = user
         self.item_dictionary_logic = {}
         self.number_of_items = len(self.item_dictionary_logic)
-        self.inv_open_sound = SoundLoader.load('sounds/general/takethat.wav')
+        self.inv_open_sound = SoundLoader.load('sounds/general/takethat.mp3')
 
     def get_item_string_list(self):
         string_list = []
@@ -52,6 +52,7 @@ class UserInventory(Popup):
         self.inv_open_sound.volume = v / 100
         item.open_popup()
         self.inv_open_sound.play()
+        self.inv_open_sound.seek(0)
 
     def delete_item(self, name):
         if name in self.item_dictionary_logic:

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 # import os
+
 #
 # wrong_path = os.environ['GST_PLUGIN_PATH']
 # right_path = os.getcwd()
@@ -93,6 +94,7 @@ class MainScreenManager(ScreenManager):
         v = config.getdefaultint('sound', 'effect_volume', 100)
         sfx.volume = v / 100
         sfx.play()
+        sfx.seek(0)
         self.current = "main"
         self.main_screen.on_ready()
         connection_manager = App.get_running_app().get_user_handler().get_connection_manager()

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,6 @@
 # fixed_path = wrong_path.replace(pattern, to_replace)
 # os.environ['GST_PLUGIN_PATH'] = fixed_path
 
-
 import set_kivy_config
 # import irc.client
 # import requests
@@ -163,7 +162,7 @@ class MysteryOnlineApp(App):
             'fav_sfx': [],
             'fav_subloc': []
         })
-        config.setdefaults('command_shortcuts', {
+        config.setdefaults('command-shortcuts', {
             '>': "/color green '>"
         })
         config.setdefaults('keybindings', {

--- a/src/ooc.py
+++ b/src/ooc.py
@@ -177,6 +177,7 @@ class MusicTab(TabbedPanelItem):
             track.volume = config_.getdefaultint('sound', 'music_volume', 100) / 100
             track.loop = root.loop
             track.play()
+            track.seek(0)
             root.track = track
             root.is_loading_music = False
             if track_name != "Hidden track":
@@ -338,6 +339,7 @@ class OOCWindow(TabbedPanel):
         pm_open_sound = SoundLoader.load('sounds/general/codecopen.mp3')
         pm_open_sound.volume = self.pm_open_sound_volume
         pm_open_sound.play()
+        pm_open_sound.seek(0)
 
     def restore_pm_button_to_normal(self, pm):
         pm.background_normal = 'atlas://data/images/defaulttheme/button'
@@ -364,6 +366,7 @@ class OOCWindow(TabbedPanel):
                             pm_notif = SoundLoader.load('sounds/general/codeccall.mp3')
                             pm_notif.volume = self.pm_notif_volume
                             pm_notif.play()
+                            pm_notif.seek(0)
                             if platform == 'win':
                                 import ctypes
                                 ctypes.windll.user32.FlashWindow(App.get_running_app().get_window_handle(), True)
@@ -422,6 +425,7 @@ class OOCWindow(TabbedPanel):
                 self.ooc_chat_header.background_color = color
             if self.ooc_play:
                 self.ooc_notif.play()
+                self.ooc_notif.seek(0)
                 config = App.get_running_app().config
                 delay = config.getdefaultint('other', 'ooc_notif_delay', 60)
                 Clock.schedule_once(self.ooc_time_callback, delay)

--- a/src/private_message_screen.py
+++ b/src/private_message_screen.py
@@ -71,6 +71,7 @@ class PrivateMessageScreen(ModalView):
         pm_close_sound = SoundLoader.load('sounds/general/codecover.mp3')
         pm_close_sound.volume = vol / 100
         pm_close_sound.play()
+        pm_close_sound.seek(0)
         self.pm_window_open_flag = False
         self.pm_flag = False
         self.text_box.text = ''

--- a/src/textbox.py
+++ b/src/textbox.py
@@ -5,9 +5,11 @@ from kivy.graphics.vertex_instructions import Rectangle
 from kivy.properties import ObjectProperty
 from kivy.uix.label import Label
 from kivy.uix.textinput import TextInput
-from kivy.utils import escape_markup
+from kivy.utils import escape_markup, platform
 from kivy.resources import resource_find
 from kivy.core.audio.audio_sdl2 import SoundSDL2
+
+from kivy.core.audio import SoundLoader
 
 import re
 from commands import command_processor, CommandInvalidArgumentsError, CommandNoArgumentsError
@@ -69,11 +71,14 @@ class TextBox(Label):
         self.rainbow_sfx = self.load_wav('sounds/general/rainbow.mp3')
 
     def load_wav(self, filename):
-        """Use SDL2 to load wav files cuz it's better"""
+        """Use SDL2 to load wav files cuz it's better, but only on windows"""
         rfn = resource_find(filename)
         if rfn is not None:
             filename = rfn
-        return SoundSDL2(source=filename)
+        if platform == 'win':
+            return SoundSDL2(source=filename)
+        else:
+            return SoundLoader.load(filename)
 
     def update_ui(self, dt):
         with self.char_name.canvas.before:
@@ -97,6 +102,7 @@ class TextBox(Label):
         vol = config.getdefaultint('sound', 'effect_volume', 100) / 100
         sfx.volume = vol
         sfx.play()
+        sfx.seek(0)
 
     def display_text(self, msg, user, color, sender):
         self.is_displaying_msg = True
@@ -127,18 +133,25 @@ class TextBox(Label):
                 self.msg = "[color={}]{}[/color]".format(user.color, self.msg)
                 if user.color == 'ff3333':
                     self.red_sfx.play()
+                    self.red_sfx.seek(0)
                 elif user.color == '00adfc':
                     self.blue_sfx.play()
+                    self.blue_sfx.seek(0)
                 elif user.color == 'ffd700':
                     self.gold_sfx.play()
+                    self.gold_sfx.seek(0)
                 elif user.color == '8b6fba':
                     self.purple_sfx.play()
+                    self.purple_sfx.seek(0)
                 elif user.color == '00cd00':
                     self.green_sfx.play()
+                    self.green_sfx.seek(0)
                 elif user.color == 'ffffff':
                     self.blip.play()
+                    self.blip.seek(0)
             else:
                 self.rainbow_sfx.play()
+                self.rainbow_sfx.seek(0)
                 msg_array = list(self.msg)
                 self.msg = ''
                 color_spectrum = ['ff3333', 'ffa500', 'ffff00', '33cc33', '00adfc', '8b6fba', 'ee82ee']
@@ -163,6 +176,7 @@ class TextBox(Label):
     def _animate(self, dt):
         try:
             self.blip.play()
+            self.blip.seek(0)
             self.text += next(self.gen)
         except StopIteration:
             self.text += " "


### PR DESCRIPTION
oh god kivy is a mess, oh fuck python is worse than I remember

Here's a list of changes

- `command_shortcuts` has been changed to `command-shortcuts`. Apparently the underscore caused an assert error on linux. Huh!
- `takethat.wav` isn't a thing but `takethat.mp3` is so I changed it.
- apparently on linux, you need to rewind all sounds back to 0. That's _fun_! So I added a `[...].seek(0)` line everywhere I could.
- `load_wav` on `textbox.py` now uses SoundLoader in platforms that aren't windows.

By the way! Funny stuff! You need to run this command:
`# pip install https://github.com/matham/ffpyplayer/archive/master.zip`
For audio to even work on Linux. If audio doesn't work, MO refuses to join the server for some reason! So yeah. Might want to add that somewhere in the wiki/install guide.

**Before merging this PR, please test that this works on Windows without issues. I have only tested this on Linux.**