### PR TITLE
Icon/sprite changing

### DIFF
--- a/src/irc_mo.py
+++ b/src/irc_mo.py
@@ -236,10 +236,12 @@ class IconMessage:
                 connection_manager.on_join(username)
         try:
             option = int(self.sprite_option)
+            old_subloc = main_screen.sprite_window.subloc
             user.set_from_msg(self.location, self.sublocation, self.position, self.sprite, self.character)
             user.set_sprite_option(option)
-            main_screen.sprite_window.set_sprite(user)
+            main_screen.sprite_window.set_sprite(user, False)
             main_screen.ooc_window.update_subloc(user.username, user.subloc.name)
+            main_screen.sprite_window.display_sub(old_subloc)
         except (AttributeError, KeyError, ValueError) as e:
             print(e)
             return

--- a/src/irc_mo.py
+++ b/src/irc_mo.py
@@ -33,6 +33,14 @@ class MessageFactory:
             result = ChatMessage("default", **kwargs)
         return result
 
+    def build_icon_message(self, **kwargs):
+        username = kwargs.get('username', None)
+        if username is not None:
+            result = IconMessage(username, **kwargs)
+        else:
+            result = IconMessage("default", **kwargs)
+        return result
+
     def build_character_message(self, character, link=None, version=None):
         result = CharacterMessage("default", character, link, version)
         return result
@@ -68,10 +76,12 @@ class MessageFactory:
     def build_choice_return_message(self, sender, questioner, whisper, selected_option):
         result = ChoiceReturnMessage(sender, questioner, whisper, selected_option)
         return result
-    
+
     def build_from_irc(self, irc_message, username):
         if irc_message.count('#') >= 8:
             result = ChatMessage(username)
+        elif irc_message.startswith("sc#"):
+            result = IconMessage(username)
         elif irc_message.startswith('c#'):
             result = CharacterMessage(username)
         elif irc_message.startswith('OOC#'):
@@ -167,7 +177,7 @@ class ChatMessage:
                 main_screen.text_box.play_sfx(self.sfx_name)
             main_screen.text_box.display_text(self.content, user, col, username)
             main_screen.ooc_window.update_subloc(user.username, user.subloc.name)
-            
+
         if self.need_to_notify(self.content, user_handler.get_user().username):
             self.notify_user()
 
@@ -182,6 +192,57 @@ class ChatMessage:
             import ctypes
             ctypes.windll.user32.FlashWindow(App.get_running_app().get_window_handle(), True)
 
+
+class IconMessage:
+
+    def __init__(self, sender, **kwargs):
+        self.components = kwargs
+        self.sender = sender
+        self.content = kwargs.get('content')
+        self.location = kwargs.get('location')
+        self.sublocation = kwargs.get('sublocation')
+        self.character = kwargs.get('character')
+        self.sprite = kwargs.get('sprite')
+        self.position = kwargs.get('position')
+        self.sprite_option = kwargs.get('sprite_option')
+        self.remove_line_breaks()
+
+    def remove_line_breaks(self):
+        if self.content is None:
+            return
+        if '\n' in self.content or '\r' in self.content:
+            self.content = self.content.replace('\n', ' ')
+            self.content = self.content.replace('\r', ' ')
+
+    def to_irc(self):
+        msg = "sc#{0[location]}#{0[sublocation]}#{0[character]}#{0[sprite]}#" \
+              "{0[position]}#{0[sprite_option]}".format(self.components)
+        return msg
+
+    def from_irc(self, message):
+        arguments = message.split('#', 6)
+        arguments.remove("sc")
+        self.location, self.sublocation, self.character, self.sprite, self.position, \
+        self.sprite_option = arguments
+
+    def execute(self, connection_manager, main_screen, user_handler):
+        username = self.sender
+        if username == "default":
+            user = App.get_running_app().get_user()
+        else:
+            connection_manager.reschedule_ping()
+            user = main_screen.users.get(username, None)
+            if user is None:
+                connection_manager.on_join(username)
+        try:
+            option = int(self.sprite_option)
+            user.set_from_msg(self.location, self.sublocation, self.position, self.sprite, self.character)
+            user.set_sprite_option(option)
+            main_screen.sprite_window.set_sprite(user)
+            main_screen.ooc_window.update_subloc(user.username, user.subloc.name)
+        except (AttributeError, KeyError, ValueError) as e:
+            print(e)
+            return
 
 class ChoiceMessage:
 
@@ -208,7 +269,7 @@ class ChoiceMessage:
         self.text, self.options, self.list_of_users = arguments
 
     def execute(self, connection_manager, main_screen, user_handler):
-        user = user_handler.get_user()            
+        user = user_handler.get_user()
         username = user.username
         log = main_screen.log_window
         options = re.split(r'(?<!\\);', self.options)
@@ -266,7 +327,7 @@ class ChoiceReturnMessage:
         else:
             if username == self.sender:
                 user_handler.send_message(self.selected_option)
-                
+
 
 class CharacterMessage:
 

--- a/src/sprite.py
+++ b/src/sprite.py
@@ -258,6 +258,7 @@ class SpriteWindow(Widget):
 
     def __init__(self, **kwargs):
         super(SpriteWindow, self).__init__(**kwargs)
+        self.subloc = None
         self.sprite_organizer = SpriteOrganizer()
         self.center_sprite = Image(allow_stretch=True, keep_ratio=False,
                                    opacity=0, size_hint=(None, None), size=(800, 600),
@@ -273,7 +274,7 @@ class SpriteWindow(Widget):
         self.sprite_organizer.add_sprite(self.right_sprite)
         self.sprite_organizer.add_sprite(self.overlay)
 
-    def set_sprite(self, user):
+    def set_sprite(self, user, display_sub=True):
         sprite = user.get_current_sprite()
         if sprite.is_cg():
             self.set_cg(sprite, user)
@@ -299,7 +300,8 @@ class SpriteWindow(Widget):
         for index, organized_sprite in enumerate(self.sprite_organizer.get_sprites()):
             self.sprite_layout.add_widget(organized_sprite, index=index)
 
-        self.display_sub(subloc)
+        if(display_sub):
+            self.display_sub(subloc)
 
     def set_cg(self, sprite, user):
         self.sprite_layout.clear_widgets()
@@ -316,6 +318,7 @@ class SpriteWindow(Widget):
         self.background.texture = subloc.get_img().texture
 
     def display_sub(self, subloc):
+        self.subloc = subloc
         if subloc.o_users:
             sprite = subloc.get_o_user().get_current_sprite()
             option = subloc.get_o_user().get_sprite_option()

--- a/src/textbox.py
+++ b/src/textbox.py
@@ -209,6 +209,9 @@ class MainTextInput(TextInput):
             popup = MOPopup("Warning", "Message too long", "OK")
             popup.open()
             return
+        elif len(self.text) == 0:
+            App.get_running_app().get_user_handler().send_icon()
+            return
         main_scr = App.get_running_app().get_main_screen()
         Clock.schedule_once(main_scr.refocus_text)
         msg = escape_markup(self.text)

--- a/src/textbox.py
+++ b/src/textbox.py
@@ -200,16 +200,22 @@ class TextBox(Label):
 class MainTextInput(TextInput):
     def __init__(self, **kwargs):
         super(MainTextInput, self).__init__(**kwargs)
+        self.icon_change_spam = False
 
     def ready(self, main_screen):
         Clock.schedule_once(main_screen.refocus_text)
+
+    def enable_icon_change(self, dt=None):
+        self.icon_change_spam = False
 
     def send_message(self, *args):
         if len(self.text) > 250:
             popup = MOPopup("Warning", "Message too long", "OK")
             popup.open()
             return
-        elif len(self.text) == 0:
+        elif len(self.text) == 0 and not self.icon_change_spam:
+            self.icon_change_spam = True
+            Clock.schedule_once(self.enable_icon_change, 1)
             App.get_running_app().get_user_handler().send_icon()
             return
         main_scr = App.get_running_app().get_main_screen()

--- a/src/user.py
+++ b/src/user.py
@@ -171,6 +171,18 @@ class CurrentUserHandler:
         self.connection_manager.send_msg(message)
         self.connection_manager.send_local(message)
 
+    def send_icon(self):
+        self.user.set_pos(self.current_pos_name)
+        loc = self.user.get_loc().name
+        char = self.user.get_char().name
+        sprite_option = self.user.get_sprite_option()
+        message_factory = App.get_running_app().get_message_factory()
+        message = message_factory.build_icon_message(location=loc, sublocation=self.current_subloc_name,
+                                                     character=char, sprite=self.current_sprite_name,
+                                                     position=self.current_pos_name, sprite_option=sprite_option)
+        self.connection_manager.send_msg(message)
+        self.connection_manager.send_local(message)
+
     def on_current_loc(self, *args):
         self.user.set_loc(self.current_loc)
         subloc_name = self.current_loc.get_first_sub()


### PR DESCRIPTION
[Video showcasing this feature](https://streamable.com/q06qk)

Basically, when you attempt to send an empty message, your sprite, subloc and position is updated accordingly on all clients, without displaying a new message, or displaying a new sublocation.

This is useful when you misclick and send a message with a emote you didn't want to use, to "react" to other people's messages, to move your character around, etc.

As of right now, there's a timer on it. You can only change your icon once for every second.