### PR TITLE
Fix emote bug

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -251,8 +251,8 @@ class CommandProcessor:
             user.get_char().load()
             main_scr.on_new_char(user.get_char())
         elif self.command['option'].lower() == 'subloc' or self.command['option'].lower() == 'sublocation':
-            user_handler.set_current_subloc_name(random.choice(user.get_loc().list_sub()))
-            main_scr.sprite_preview.set_subloc(user_handler.get_current_subloc())
+            user_handler.set_chosen_subloc_name(random.choice(user.get_loc().list_sub()))
+            main_scr.sprite_preview.set_subloc(user_handler.get_chosen_subloc())
         elif self.command['option'].lower() == 'music' or self.command['option'].lower() == 'track':
             try:
                 main_scr.left_tab.music_list.tracks[random.choice(list(main_scr.left_tab.music_list.tracks))].on_selected()

--- a/src/icon.py
+++ b/src/icon.py
@@ -116,17 +116,22 @@ class IconsLayout(BoxLayout):
         self.loading = True
         self.current_page = 1
         self.add_widget(self.grids[0], index=1)
-        self.sprite_picked(self.grids[0].children[-1])
+        self.sprite_picked(self.grids[0].children[-1], None, True)
         self.loading = False
 
-    def sprite_picked(self, icon, sprite_name=None):
+    def sprite_picked(self, icon, sprite_name=None, current=False):
         if sprite_name is None:
             sprite_name = icon.name
         main_scr = App.get_running_app().get_main_screen()
         user_handler = App.get_running_app().get_user_handler()
-        user_handler.set_current_sprite_name(sprite_name)
-        sprite = user_handler.get_current_sprite()
-        setting = user_handler.get_current_sprite_option
+        if current:
+            user_handler.set_current_sprite_name(sprite_name)
+            sprite = user_handler.get_current_sprite()
+            setting = user_handler.get_current_sprite_option
+        else:
+            user_handler.set_chosen_sprite_name(sprite_name)
+            sprite = user_handler.get_chosen_sprite()
+            setting = user_handler.get_chosen_sprite_option
         sprite = main_scr.sprite_settings.apply_post_processing(sprite, setting)
         main_scr.sprite_preview.set_sprite(sprite)
         Clock.schedule_once(main_scr.refocus_text, 0.2)
@@ -142,7 +147,7 @@ class IconsLayout(BoxLayout):
         main_scr = App.get_running_app().get_main_screen()
         char = main_scr.user.get_char()
         user_handler = App.get_running_app().get_user_handler()
-        sprite_option = user_handler.get_current_sprite_option()
+        sprite_option = user_handler.get_chosen_sprite_option()
         sprite = char.get_sprite(sprite_name)
         main_scr.sprite_settings.apply_post_processing(sprite, sprite_option)
         sprite_texture = char.get_sprite(sprite_name).get_texture()

--- a/src/icon.py
+++ b/src/icon.py
@@ -117,6 +117,7 @@ class IconsLayout(BoxLayout):
         self.current_page = 1
         self.add_widget(self.grids[0], index=1)
         self.sprite_picked(self.grids[0].children[-1], None, True)
+        self.sprite_picked(self.grids[0].children[-1], None, False)
         self.loading = False
 
     def sprite_picked(self, icon, sprite_name=None, current=False):

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,7 @@
-# import os
+import os, platform
+
+if(platform.system() == "Linux"):
+    os.environ["KIVY_WINDOW"] = "x11"
 
 #
 # wrong_path = os.environ['GST_PLUGIN_PATH']

--- a/src/mainscreen.py
+++ b/src/mainscreen.py
@@ -81,7 +81,7 @@ class RightClickMenu(ModalView):
             return
         user_handler.set_current_loc(loc)
         main_scr.sprite_settings.update_sub(loc)
-        main_scr.sprite_preview.set_subloc(user_handler.get_current_subloc())
+        main_scr.sprite_preview.set_subloc(user_handler.get_chosen_subloc())
 
 
 class MainScreen(Screen):
@@ -151,7 +151,7 @@ class MainScreen(Screen):
             self.sprite_settings.update_sub(locations['Hakuryou'])
         self.toolbar.set_user(self.user)
         self.toolbar.create_sfx_dropdown()
-        self.sprite_preview.set_subloc(user_handler.get_current_subloc())
+        self.sprite_preview.set_subloc(user_handler.get_chosen_subloc())
         char = self.user.get_char()
         if char is not None:
             self.on_new_char(char)

--- a/src/sprite.py
+++ b/src/sprite.py
@@ -157,11 +157,11 @@ class SpriteSettings(BoxLayout):
     def on_checked_flip_h(self, value):
         user_handler = App.get_running_app().get_user_handler()
         if value:
-            user_handler.set_current_sprite_option(0)
+            user_handler.set_chosen_sprite_option(0)
         else:
-            user_handler.set_current_sprite_option(1)
-        sprite = user_handler.get_current_sprite()
-        sprite_option = user_handler.get_current_sprite_option()
+            user_handler.set_chosen_sprite_option(1)
+        sprite = user_handler.get_chosen_sprite()
+        sprite_option = user_handler.get_chosen_sprite_option()
         sprite = self.apply_post_processing(sprite, sprite_option)
         main_scr = App.get_running_app().get_main_screen()
         main_scr.sprite_preview.set_sprite(sprite)
@@ -193,7 +193,7 @@ class SpriteSettings(BoxLayout):
         self.pos_btn.text = pos
         main_scr = App.get_running_app().get_main_screen()
         user_handler = App.get_running_app().get_user_handler()
-        user_handler.set_current_pos_name(pos)
+        user_handler.set_chosen_pos_name(pos)
         main_scr.refocus_text()
 
     def create_subloc_drop(self):
@@ -204,8 +204,8 @@ class SpriteSettings(BoxLayout):
         self.subloc_btn.text = subloc_name
         main_scr = App.get_running_app().get_main_screen()
         user_handler = App.get_running_app().get_user_handler()
-        user_handler.set_current_subloc_name(subloc_name)
-        sub = user_handler.get_current_subloc()
+        user_handler.set_chosen_subloc_name(subloc_name)
+        sub = user_handler.get_chosen_subloc()
         main_scr.sprite_preview.set_subloc(sub)
         main_scr.refocus_text()
 
@@ -246,7 +246,7 @@ class SpritePreview(Image):
     def set_sprite(self, sprite):
         user_handler = App.get_running_app().get_user_handler()
         main_scr = App.get_running_app().get_main_screen()
-        sprite_option = user_handler.get_current_sprite_option()
+        sprite_option = user_handler.get_chosen_sprite_option()
         sprite = main_scr.sprite_settings.apply_post_processing(sprite, sprite_option)
         self.center_sprite.texture = None
         self.center_sprite.texture = sprite.get_texture()

--- a/src/user.py
+++ b/src/user.py
@@ -153,40 +153,55 @@ class CurrentUserHandler:
         self.current_subloc_name = ""
         self.current_pos_name = ""
         self.current_sprite_option = -1
+        self.chosen_sprite_name = ""
+        self.chosen_subloc_name = ""
+        self.chosen_pos_name = ""
+        self.chosen_sprite_option = -1
 
     def send_message(self, msg):
-        self.user.set_pos(self.current_pos_name)
         col_id = 0
         if self.user.colored:
             col_id = self.user.color_ids.index(self.user.get_color())
         loc = self.user.get_loc().name
         char = self.user.get_char().name
-        sprite_option = self.user.get_sprite_option()
         message_factory = App.get_running_app().get_message_factory()
         sfx_name = App.get_running_app().get_main_screen().get_toolbar().get_sfx_name()
-        message = message_factory.build_chat_message(content=msg, location=loc, sublocation=self.current_subloc_name,
-                                                     character=char, sprite=self.current_sprite_name,
-                                                     position=self.current_pos_name, color_id=col_id,
-                                                     sprite_option=sprite_option, sfx_name=sfx_name)
+        message = message_factory.build_chat_message(content=msg, location=loc, sublocation=self.chosen_subloc_name,
+                                                     character=char, sprite=self.chosen_sprite_name,
+                                                     position=self.chosen_pos_name, color_id=col_id,
+                                                     sprite_option=self.get_chosen_sprite_option(), sfx_name=sfx_name)
+
+        self.chosen_to_current()
+        self.user.set_pos(self.current_pos_name)
+
         self.connection_manager.send_msg(message)
         self.connection_manager.send_local(message)
 
     def send_icon(self):
-        self.user.set_pos(self.current_pos_name)
         loc = self.user.get_loc().name
         char = self.user.get_char().name
-        sprite_option = self.user.get_sprite_option()
         message_factory = App.get_running_app().get_message_factory()
-        message = message_factory.build_icon_message(location=loc, sublocation=self.current_subloc_name,
-                                                     character=char, sprite=self.current_sprite_name,
-                                                     position=self.current_pos_name, sprite_option=sprite_option)
+        message = message_factory.build_icon_message(location=loc, sublocation=self.chosen_subloc_name,
+                                                     character=char, sprite=self.chosen_sprite_name,
+                                                     position=self.chosen_pos_name,
+                                                     sprite_option=self.chosen_sprite_option)
+
+        self.chosen_to_current()
+        self.user.set_pos(self.current_pos_name)
+
         self.connection_manager.send_msg(message)
         self.connection_manager.send_local(message)
+
+    def chosen_to_current(self):
+        self.set_current_pos_name(self.get_chosen_pos_name())
+        self.set_current_sprite_name(self.get_chosen_sprite_name())
+        self.set_current_sprite_option(self.get_chosen_sprite_option())
+        self.set_current_subloc_name(self.get_chosen_subloc_name())
 
     def on_current_loc(self, *args):
         self.user.set_loc(self.current_loc)
         subloc_name = self.current_loc.get_first_sub()
-        self.set_current_subloc_name(subloc_name)
+        self.set_chosen_subloc_name(subloc_name)
         message_factory = App.get_running_app().get_message_factory()
         message = message_factory.build_location_message(self.current_loc.name)
         self.connection_manager.send_msg(message)
@@ -207,6 +222,9 @@ class CurrentUserHandler:
     def get_current_sprite(self):
         return self.user.get_current_sprite()
 
+    def get_chosen_sprite(self):
+        return self.user.get_char().get_sprite(self.chosen_sprite_name)
+
     def set_connection_manager(self, connection_manager):
         self.connection_manager = connection_manager
 
@@ -216,6 +234,33 @@ class CurrentUserHandler:
     def set_current_sprite_name(self, sprite_name):
         self.current_sprite_name = sprite_name
         self.on_current_sprite_name()
+
+    def set_chosen_sprite_name(self, sprite_name):
+        self.chosen_sprite_name = sprite_name
+
+    def get_chosen_sprite_name(self):
+        return self.chosen_sprite_name
+
+    def set_chosen_subloc_name(self, subloc_name):
+        self.chosen_subloc_name = subloc_name
+
+    def get_chosen_subloc(self):
+        return self.user.get_loc().get_sub(self.get_chosen_subloc_name())
+
+    def get_chosen_subloc_name(self):
+        return self.chosen_subloc_name
+
+    def set_chosen_pos_name(self, pos_name):
+        self.chosen_pos_name = pos_name
+
+    def get_chosen_pos_name(self):
+        return self.chosen_pos_name
+
+    def set_chosen_sprite_option(self, sprite_option):
+        self.chosen_sprite_option = sprite_option
+
+    def get_chosen_sprite_option(self):
+        return self.chosen_sprite_option
 
     def get_current_sprite_name(self):
         return self.current_sprite_name


### PR DESCRIPTION
Before, when changing position, sublocation, emote, sprite options, it would override the local user's parameters with those. That would have been fine, but when the sublocation you're in is updated (when someone next to you sends a message or an icon, for example) then your local sprite would be changed as well. That's obviously bad.

With this PR, I introduced new "chosen" variables, so we can keep the new parameters for the emotes without overriding the "real" ones. When we actually send a message, the chosen variables overwrite the "real" or current ones.

I've tested this PR and so far it works as it should, but I can't promise it's entirely bug free. That being said, this does at least fix the bug described above.

Also added a fix for linux where FPS would drop significantly when using big characters. However, since it now uses bare x11, the app has no icon and hovering sprites doesn't quite work as it does in Windows or with SDL2. Whoops. A small price to pay for it to work with big characters imo. (I'll try to fix that in the future)