### PR TITLE
Makes tooltips efficient, ACTUAL LINUX SUPPORT

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,9 +6,6 @@ if len(argv) > 1 and argv[1] == "--dev":
     set_dev(True)
     del argv[1]
 
-if platform.system() == "Linux":
-    os.environ["KIVY_WINDOW"] = "x11"
-
 #
 # wrong_path = os.environ['GST_PLUGIN_PATH']
 # right_path = os.getcwd()


### PR DESCRIPTION
Resolves #82 
So basically, instead of having n on_mouse_pos binds, we have a single one for the icon manager thing, and then we check every icon being shown atm for collisions. This is much more efficient.

ALSO LINUX SUPPORT