### PR TITLE
Youtube music thread safety, proper audio and tooltip fix

### DIFF
--- a/src/icon.py
+++ b/src/icon.py
@@ -78,9 +78,7 @@ class IconsLayout(BoxLayout):
             return
 
         if not self.collide_point(*pos):
-            if self.scheduled_icon is not None:
-                Clock.unschedule(self.scheduled_icon.display_tooltip)
-                self.scheduled_icon.close_tooltip()
+            self.on_hover_out()
             return
 
         for child in self.grids[self.current_page-1].children:
@@ -88,12 +86,15 @@ class IconsLayout(BoxLayout):
                 continue
 
             if child.collide_point(*pos):
-                Clock.schedule_once(child.display_tooltip, 0.4)
-                self.scheduled_icon = child
+                if self.scheduled_icon != child:
+                    if self.scheduled_icon is not None:
+                        Clock.unschedule(self.scheduled_icon.display_tooltip)
+                        self.on_hover_out()
+                        Clock.schedule_once(child.display_tooltip, 0.2)
+                    else:
+                        Clock.schedule_once(child.display_tooltip, 0.4)
+                    self.scheduled_icon = child
                 break
-            else:
-                Clock.unschedule(child.display_tooltip)  # cancel scheduled event since I moved the cursor
-                child.close_tooltip()  # close if it's opened
 
     def load_icons(self, char):
         icons = char.get_icons()

--- a/src/inventory.py
+++ b/src/inventory.py
@@ -24,7 +24,6 @@ class UserInventory(Popup):
         self.user = user
         self.item_dictionary_logic = {}
         self.number_of_items = len(self.item_dictionary_logic)
-        self.inv_open_sound = SoundLoader.load('sounds/general/takethat.mp3')
 
     def get_item_string_list(self):
         string_list = []
@@ -49,10 +48,10 @@ class UserInventory(Popup):
         self.item_list.add_widget(item)
         config = App.get_running_app().config
         v = config.getdefaultint('sound', 'effect_volume', 100)
-        self.inv_open_sound.volume = v / 100
         item.open_popup()
-        self.inv_open_sound.play()
-        self.inv_open_sound.seek(0)
+        inv_open_sound = SoundLoader.load('sounds/general/takethat.mp3')
+        App.get_running_app().play_sound(inv_open_sound, volume=v / 100.0)
+
 
     def delete_item(self, name):
         if name in self.item_dictionary_logic:

--- a/src/main.py
+++ b/src/main.py
@@ -26,7 +26,7 @@ from kivy.uix.screenmanager import ScreenManager
 from kivy.properties import ObjectProperty, BooleanProperty
 from kivy.clock import Clock
 from kivy.lang.builder import Builder
-from kivy.core.audio import SoundLoader
+from kivy.core.audio import SoundLoader, Sound
 from kivy.utils import platform
 from kivy.uix.popup import Popup
 from kivy.uix.label import Label
@@ -94,9 +94,7 @@ class MainScreenManager(ScreenManager):
         config = App.get_running_app().config
         sfx = SoundLoader.load('sounds/general/login.mp3')
         v = config.getdefaultint('sound', 'effect_volume', 100)
-        sfx.volume = v / 100
-        sfx.play()
-        sfx.seek(0)
+        App.get_running_app().play_sound(sfx, volume=v / 100.0)
         self.current = "main"
         self.main_screen.on_ready()
         connection_manager = App.get_running_app().get_user_handler().get_connection_manager()
@@ -343,6 +341,16 @@ class MysteryOnlineApp(App):
                                 character=self.user.get_char().name, sprite=self.user.get_current_sprite().name,
                                 position=self.user.get_pos(), sprite_option=self.user_handler.get_current_sprite_option())
         self.user_handler.get_connection_manager().send_msg(np_message)
+
+    def play_sound(self, sound: Sound, loop=False, volume=1.0):
+        """Kivy is a mess, so we need to do this for *every* audio we want to play."""
+        sound.load()
+        sound.loop = loop
+        sound.volume = volume
+        sound.play()
+        if not loop:
+            Clock.schedule_once(lambda delta: sound.unload(), sound.length)
+        sound.seek(0)
 
 
 if __name__ == "__main__":

--- a/src/ooc.py
+++ b/src/ooc.py
@@ -254,12 +254,19 @@ class OOCWindow(TabbedPanel):
         self.ooc_chat.bind(on_ref_press=main_scr.log_window.copy_text)
         self.chat_grid.add_widget(self.ooc_chat)
         config = App.get_running_app().config  # The main config
+        v = config.getdefaultint('sound', 'effect_volume', 100)
         config.add_callback(self.on_blip_volume_change, 'sound', 'blip_volume')
         self.blip_slider.value = config.getdefaultint('sound', 'blip_volume', 100)
         config.add_callback(self.on_music_volume_change, 'sound', 'music_volume')
         self.music_slider.value = config.getdefaultint('sound', 'music_volume', 100)
         config.add_callback(self.on_ooc_volume_change, 'sound', 'effect_volume')
-        self.effect_slider.value = config.getdefaultint('sound', 'effect_volume', 100)
+        self.effect_slider.value = v
+        try:
+            self.ooc_notif.volume = int(v) / 100.0
+            self.pm_notif_volume = int(v) / 100.0
+            self.pm_open_sound_volume = int(v) / 100.0
+        except AttributeError:
+            pass
         self.ooc_chat_header.bind(on_press=self.on_ooc_checked)
         self.chat.ready()
         main_scr = App.get_running_app().get_main_screen()
@@ -267,10 +274,6 @@ class OOCWindow(TabbedPanel):
             self.chat.irc = main_scr.manager.irc_connection
         self.chat.username = main_scr.user.username
         Clock.schedule_interval(self.update_private_messages, 1.0 / 60.0)
-        v = config.getdefaultint('sound', 'effect_volume', 100)
-        self.ooc_notif.volume = v / 100.0
-        self.pm_notif_volume = v / 100.0
-        self.pm_open_sound_volume = v / 100.0
         self.user_list.bind(minimum_height=self.user_list.setter('height'))
 
     def on_blip_volume_change(self, s, k, v):
@@ -293,9 +296,12 @@ class OOCWindow(TabbedPanel):
 
     def on_ooc_volume_change(self, s, k, v):
         self.effect_slider.value = v
-        self.ooc_notif.volume = int(v) / 100.0
-        self.pm_notif_volume = int(v) / 100.0
-        self.pm_open_sound_volume = int(v) / 100.0
+        try:
+            self.ooc_notif.volume = int(v) / 100.0
+            self.pm_notif_volume = int(v) / 100.0
+            self.pm_open_sound_volume = int(v) / 100.0
+        except AttributeError:
+            pass
 
     def on_slider_effect_value(self, *args):
         config = App.get_running_app().config

--- a/src/ooc.py
+++ b/src/ooc.py
@@ -176,13 +176,11 @@ class MusicTab(TabbedPanelItem):
                         main_scr.music_name_display.text = "Error"
                     return
             track = SoundLoader.load("mucache/"+songtitle+".mp3")
-            track.volume = config_.getdefaultint('sound', 'music_volume', 100) / 100
-            track.loop = root.loop
-            track.play()
-            track.seek(0)
+            App.get_running_app().play_sound(track, root.loop, config_.getdefaultint('sound', 'music_volume', 100) / 100.0)
             with root.track_lock:
                 if root.track is not None:
                     root.track.stop()
+                    root.track.unload()
                 root.track = track
             root.is_loading_music = False
             if track_name != "Hidden track":
@@ -200,6 +198,7 @@ class MusicTab(TabbedPanelItem):
             if self.track is not None:
                 if self.track.state == 'play':
                     self.track.stop()
+                    self.track.unload()
                     main_screen = App.get_running_app().get_main_screen()
                     main_screen.music_name_display.text = "Playing: "
                     if local:
@@ -221,6 +220,7 @@ class MusicTab(TabbedPanelItem):
         with self.track_lock:
             if self.track is not None:
                 self.track.stop()
+                self.track.unload()
 
 
 class OOCWindow(TabbedPanel):
@@ -237,6 +237,7 @@ class OOCWindow(TabbedPanel):
         super(OOCWindow, self).__init__(**kwargs)
         self.online_users = {}
         self.ooc_notif = SoundLoader.load('sounds/general/notification.mp3')
+        self.ooc_notif.unload()
         self.pm_notif_volume =0
         self.pm_open_sound_volume = 0
         self.ooc_play = True
@@ -267,9 +268,9 @@ class OOCWindow(TabbedPanel):
         self.chat.username = main_scr.user.username
         Clock.schedule_interval(self.update_private_messages, 1.0 / 60.0)
         v = config.getdefaultint('sound', 'effect_volume', 100)
-        self.ooc_notif.volume = v / 100
-        self.pm_notif_volume = v / 100
-        self.pm_open_sound_volume = v / 100
+        self.ooc_notif.volume = v / 100.0
+        self.pm_notif_volume = v / 100.0
+        self.pm_open_sound_volume = v / 100.0
         self.user_list.bind(minimum_height=self.user_list.setter('height'))
 
     def on_blip_volume_change(self, s, k, v):
@@ -292,9 +293,9 @@ class OOCWindow(TabbedPanel):
 
     def on_ooc_volume_change(self, s, k, v):
         self.effect_slider.value = v
-        self.ooc_notif.volume = int(v) / 100
-        self.pm_notif_volume = int(v) / 100
-        self.pm_open_sound_volume = int(v) / 100
+        self.ooc_notif.volume = int(v) / 100.0
+        self.pm_notif_volume = int(v) / 100.0
+        self.pm_open_sound_volume = int(v) / 100.0
 
     def on_slider_effect_value(self, *args):
         config = App.get_running_app().config
@@ -345,9 +346,7 @@ class OOCWindow(TabbedPanel):
         self.chat.set_current_conversation_user(username)
         self.chat.open()
         pm_open_sound = SoundLoader.load('sounds/general/codecopen.mp3')
-        pm_open_sound.volume = self.pm_open_sound_volume
-        pm_open_sound.play()
-        pm_open_sound.seek(0)
+        App.get_running_app().play_sound(pm_open_sound, volume=self.pm_open_sound_volume)
 
     def restore_pm_button_to_normal(self, pm):
         pm.background_normal = 'atlas://data/images/defaulttheme/button'
@@ -372,9 +371,7 @@ class OOCWindow(TabbedPanel):
                                 break
                         if not self.chat.pm_flag and not self.chat.pm_window_open_flag:
                             pm_notif = SoundLoader.load('sounds/general/codeccall.mp3')
-                            pm_notif.volume = self.pm_notif_volume
-                            pm_notif.play()
-                            pm_notif.seek(0)
+                            App.get_running_app().play_sound(pm_notif, volume=self.pm_notif_volume)
                             App.get_running_app().flash_window()
                             if not Window.focus:
                                 App.get_running_app().notification("Mystery Online", "You've got a PM from {0}".format(pm.sender))
@@ -432,8 +429,7 @@ class OOCWindow(TabbedPanel):
                 self.ooc_chat_header.background_normal = ''
                 self.ooc_chat_header.background_color = color
             if self.ooc_play:
-                self.ooc_notif.play()
-                self.ooc_notif.seek(0)
+                App.get_running_app().play_sound(self.ooc_notif)
                 config = App.get_running_app().config
                 delay = config.getdefaultint('other', 'ooc_notif_delay', 60)
                 Clock.schedule_once(self.ooc_time_callback, delay)

--- a/src/private_message_screen.py
+++ b/src/private_message_screen.py
@@ -67,11 +67,9 @@ class PrivateMessageScreen(ModalView):
         self.current_conversation = conversation
 
     def prv_chat_close_btn(self):
-        vol = App.get_running_app().config.getdefaultint('sound', 'effect_volume', 100)
+        v = App.get_running_app().config.getdefaultint('sound', 'effect_volume', 100)
         pm_close_sound = SoundLoader.load('sounds/general/codecover.mp3')
-        pm_close_sound.volume = vol / 100
-        pm_close_sound.play()
-        pm_close_sound.seek(0)
+        App.get_running_app().play_sound(pm_close_sound, volume=v / 100.0)
         self.pm_window_open_flag = False
         self.pm_flag = False
         self.text_box.text = ''

--- a/src/textbox.py
+++ b/src/textbox.py
@@ -64,6 +64,7 @@ class TextBox(Label):
         self.sfx["8b6fba"] = self.load_wav('sounds/general/purple.mp3')
         self.sfx["rainbow"] = self.load_wav('sounds/general/rainbow.mp3')
         self.sfx["ffffff"] = self.load_wav('sounds/general/blip.wav')
+        self.sfx["ffffff"].load()
 
     def load_wav(self, filename):
         """Use SDL2 to load wav files cuz it's better, but only on windows"""
@@ -126,7 +127,6 @@ class TextBox(Label):
             self.gen = text_gen(self.msg)
             config = App.get_running_app().config
             speed = config.getdefaultint('other', 'textbox_speed', 60)
-            self.sfx["ffffff"].load()
             self.sfx["ffffff"].volume = self.volume
             Clock.schedule_interval(self._animate, 1.0 / speed)
         else:
@@ -164,9 +164,11 @@ class TextBox(Label):
             self.text += next(self.gen)
         except StopIteration:
             self.text += " "
-            Clock.schedule_once(lambda delta: self.sfx["ffffff"].unload(), self.sfx["ffffff"].length)
             self.is_displaying_msg = False
             return False
+
+    def unload_blip(self, delta):
+        self.sfx["ffffff"].unload()
 
     def clear_textbox(self):
         self.text = ""

--- a/src/textbox.py
+++ b/src/textbox.py
@@ -27,6 +27,7 @@ class TextBox(Label):
         self.markup = True
         self.gen = None
         self.sfx = {}
+        self.volume = 1.0
         self.char_name_color = None
         self.char_name_rect = None
         self.textbox_color = None
@@ -93,7 +94,7 @@ class TextBox(Label):
     def play_sfx(self, sfx_name):
         sfx = self.load_wav('sounds/sfx/{0}'.format(sfx_name))
         config = App.get_running_app().config
-        v = config.getdefaultint('sound', 'effect_volume', 100)
+        v = config.getdefaultint('sound', 'effect_volume', 100) / 100.0
         App.get_running_app().play_sound(sfx, volume=v)
 
     def display_text(self, msg, user, color, sender):
@@ -120,10 +121,11 @@ class TextBox(Label):
             config = App.get_running_app().config
             speed = config.getdefaultint('other', 'textbox_speed', 60)
             self.sfx["ffffff"].load()
+            self.sfx["ffffff"].volume = self.volume
             Clock.schedule_interval(self._animate, 1.0 / speed)
         else:
             if user.color in self.sfx:
-                App.get_running_app().play_sound(self.sfx[user.color])
+                App.get_running_app().play_sound(self.sfx[user.color], volume=self.volume)
 
             if user.color != 'rainbow':
                 self.msg = "[color={}]{}[/color]".format(user.color, self.msg)
@@ -164,10 +166,13 @@ class TextBox(Label):
         self.text = ""
 
     def on_volume_change(self, s, k, v):
-        vol = int(v) / 100.0
-        for sfx in self.sfx.values():
-            sfx.volume = vol * 0.5
-        self.sfx["ffffff"].volume = vol
+        self.volume = int(v) / 100.0
+        try:
+            for sfx in self.sfx.values():
+                sfx.volume = self.volume * 0.5
+            self.sfx["ffffff"].volume = self.volume
+        except AttributeError:
+            pass
 
 class MainTextInput(TextInput):
     def __init__(self, **kwargs):


### PR DESCRIPTION
Now two songs cannot be played at once.
Also, we handle audio better now. Specially on linux.
All(*) audio that plays should go through a method(**) on the main app.

(*)except for audio that plays repeatedly. In that case you need to load and unload the audio manually. Check how blips work to get an idea.
(**)if your audio loops, you need to unload it yourself when it stops playing.